### PR TITLE
Do not raise unhandled exception on unknown --output_type

### DIFF
--- a/youtokentome/yttm_cli.py
+++ b/youtokentome/yttm_cli.py
@@ -80,7 +80,10 @@ def bpe(data, model, vocab_size, coverage, n_threads, pad_id, unk_id, bos_id, eo
     help="Path to file with learned model.",
 )
 @click.option(
-    "--output_type", type=click.STRING, required=True, help="'id' or 'subword'."
+    "--output_type",
+    type=click.Choice(["id", "subword"]),
+    required=True,
+    help="'id' or 'subword'.",
 )
 @click.option(
     "--n_threads",
@@ -97,12 +100,6 @@ def bpe(data, model, vocab_size, coverage, n_threads, pad_id, unk_id, bos_id, eo
 )
 def encode(model, output_type, n_threads, bos, eos, reverse, stream):
     """Encode text to ids or subwords."""
-    output_type = output_type.lower()
-    if output_type != "id" and output_type != "subword":
-        raise ValueError(
-            'Invalid value for "--output_type": must be equal to "id" or "subword", not "%d".'
-            % output_type
-        )
     if n_threads < -1 or n_threads == 0:
         raise ValueError(
             'Invalid value for "--n_threads": must be -1 or positive integer, not "%d"'


### PR DESCRIPTION
`yttm encode` was failing like this on invalid `--output_type`:
```
...
  File "/home/silver/miniconda3/lib/python3.6/site-packages/youtokentome/yttm_cli.py", line 104, in encode
    % output_type
TypeError: %d format: a number is required, not str
```

This could be fixed by fixing a format string from `%d` to `%s`, but a better option is to let Click handle args validation.