### PR TITLE
Fix install Cython errors on pip & poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["Cython>=0.29.34", "setuptools>=32.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ setuptools>=32.0.0
 Click>=7.0
 pytest==4.3.1
 tabulate==0.8.5
-Cython==0.29.14
+Cython>=0.29.34


### PR DESCRIPTION
Thanks for your work on this package but it seems it's falling behind in maintenance. It needs upgraded `Cython` as build dependency, and requires downgraded Python (3.9.16) in some cases. Relevant Issues:
- https://github.com/MahmoudAshraf97/whisper-diarization/issues/33

This PR was created to address this issue, but remained stale because nobody with write permissions approved:
- https://github.com/VKCOM/YouTokenToMe/pull/103

In fact, this PR is now too stale to be helpful. Here's another attempt to fix this library so it can actually be installed without downgrades, etc.

Instead of pinning Cython at a specific version I made a min version starting now.